### PR TITLE
[fix] compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ add_executable(example_gazebo_node src/example_gazebo_node.cpp)
 add_executable(example_moveit_node src/example_moveit_node.cpp)
 
 add_dependencies(hebiros_node hebiros_generate_messages_cpp)
-add_dependencies(example_01_loolup_node hebiros_generate_messages_cpp)
+add_dependencies(example_01_lookup_node hebiros_generate_messages_cpp)
 add_dependencies(example_02_feedback_node hebiros_generate_messages_cpp)
 add_dependencies(example_03_command_node hebiros_generate_messages_cpp)
 add_dependencies(example_gazebo_node hebiros_generate_messages_cpp)
@@ -194,13 +194,13 @@ add_dependencies(example_moveit_node hebiros_generate_messages_cpp)
 #   ${catkin_LIBRARIES}
 # )
 
-target_link_libraries(hebiros_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/lib/linux_x86_64/libhebi.so)
+target_link_libraries(hebiros_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/lib/linux_x86_64/libhebi.so)
 
-target_link_libraries(example_01_lookup_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/lib/linux_x86_64/libhebi.so)
-target_link_libraries(example_02_feedback_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/lib/linux_x86_64/libhebi.so)
-target_link_libraries(example_03_command_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/lib/linux_x86_64/libhebi.so)
-target_link_libraries(example_gazebo_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/lib/linux_x86_64/libhebi.so)
-target_link_libraries(example_moveit_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/lib/linux_x86_64/libhebi.so)
+target_link_libraries(example_01_lookup_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/lib/linux_x86_64/libhebi.so)
+target_link_libraries(example_02_feedback_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/lib/linux_x86_64/libhebi.so)
+target_link_libraries(example_03_command_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/lib/linux_x86_64/libhebi.so)
+target_link_libraries(example_gazebo_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/lib/linux_x86_64/libhebi.so)
+target_link_libraries(example_moveit_node ${catkin_LIBRARIES} ${CMAKE_SOURCE_DIR}/lib/linux_x86_64/libhebi.so)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,11 @@ add_executable(example_gazebo_node src/example_gazebo_node.cpp)
 add_executable(example_moveit_node src/example_moveit_node.cpp)
 
 add_dependencies(hebiros_node hebiros_generate_messages_cpp)
+add_dependencies(example_01_loolup_node hebiros_generate_messages_cpp)
+add_dependencies(example_02_feedback_node hebiros_generate_messages_cpp)
+add_dependencies(example_03_command_node hebiros_generate_messages_cpp)
+add_dependencies(example_gazebo_node hebiros_generate_messages_cpp)
+add_dependencies(example_moveit_node hebiros_generate_messages_cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/package.xml
+++ b/package.xml
@@ -32,11 +32,11 @@
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
   <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+  <build_depend>message_generation</build_depend>
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
+  <run_depend>message_runtime</run_depend>
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Hi all.
I tried to use HEBI-ARM (5motors) in [World Moveit! Day Tokyo 2017](http://moveit.ros.org/events/world-moveit-day-2017/). #WMD2017
And I got 2 types of compile error.
Here is the error and what I fixed it.
### 1. lib files (*.so) is not found because of mistaken path
Compile error message was following.
```bash
Errors     << hebiros:make /home/ryodo/workspace/ROS/hebi_pr_ws/logs/hebiros/build.make.004.log                                                                                           
make[2]: *** make[2]: *** No rule to make target `/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/hebiros/lib/linux_x86_64/libhebi.so', needed by `/home/ryodo/workspace/ROS/hebi_pr_ws/devel/.private/hebiros/lib/hebiros/example_01_lookup_node'No rule to make target `/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/hebiros/lib/linux_x86_64/libhebi.so', needed by `/home/ryodo/workspace/ROS/hebi_pr_ws/devel/.private/hebiros/lib/hebiros/example_gazebo_node'.  Stop.
make[2]: *** No rule to make target `/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/hebiros/lib/linux_x86_64/libhebi.so', needed by `/home/ryodo/workspace/ROS/hebi_pr_ws/devel/.private/hebiros/lib/hebiros/example_03_command_node'.  Stop.
make[1]: *** [CMakeFiles/example_gazebo_node.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
.  Stop.
make[1]: *** [CMakeFiles/example_03_command_node.dir/all] Error 2
make[1]: *** [CMakeFiles/example_01_lookup_node.dir/all] Error 2
make[2]: *** No rule to make target `/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/hebiros/lib/linux_x86_64/libhebi.so', needed by `/home/ryodo/workspace/ROS/hebi_pr_ws/devel/.private/hebiros/lib/hebiros/example_02_feedback_node'.  Stop.
make[1]: *** [CMakeFiles/example_02_feedback_node.dir/all] Error 2
make: *** [all] Error 2
cd /home/ryodo/workspace/ROS/hebi_pr_ws/build/hebiros; catkin build --get-env hebiros | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
```
what I did is dfc3b2c .

#### 2. Message generation error
Compile error message was following.
```bash
Errors     << hebiros:make /home/ryodo/workspace/ROS/hebi_pr_ws/logs/hebiros/build.make.000.log                                                                                           
/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/src/example_01_lookup_node.cpp:2:34: fatal error: hebiros/EntryListSrv.h: No such file or directory
 #include "hebiros/EntryListSrv.h"
                                  ^
compilation terminated.
/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/src/example_02_feedback_node.cpp:2:33: fatal error: hebiros/FeedbackMsg.h: No such file or directory
 #include "hebiros/FeedbackMsg.h"
                                 ^
compilation terminated.
/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/src/example_gazebo_node.cpp:7:41: fatal error: hebiros/AddGroupFromUrdfSrv.h: No such file or directory
 #include "hebiros/AddGroupFromUrdfSrv.h"
                                         ^
compilation terminated.
/home/ryodo/workspace/ROS/hebi_pr_ws/src/HEBI-ROS/src/example_03_command_node.cpp:3:42: fatal error: hebiros/AddGroupFromNamesSrv.h: No such file or directory
 #include "hebiros/AddGroupFromNamesSrv.h"
                                          ^
compilation terminated.
make[2]: *** [CMakeFiles/example_01_lookup_node.dir/src/example_01_lookup_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/example_01_lookup_node.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/example_02_feedback_node.dir/src/example_02_feedback_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/example_02_feedback_node.dir/all] Error 2
make[2]: *** [CMakeFiles/example_gazebo_node.dir/src/example_gazebo_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/example_gazebo_node.dir/all] Error 2
make[2]: *** [CMakeFiles/example_03_command_node.dir/src/example_03_command_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/example_03_command_node.dir/all] Error 2
make: *** [all] Error 2
cd /home/ryodo/workspace/ROS/hebi_pr_ws/build/hebiros; catkin build --get-env hebiros | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd 
```
What I did is 2ce2a49 219e995 .

---
I hope this PR works for everyone.

Thank you.
Best regards.