### PR TITLE
Fix build issue. Add CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
   email:
     on_failure: always
     recipients:
-      - 130s@2000.jukuin.keio.ac.jp
+      - developer@hebirobotics.com
 env:
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu VERBOSE_OUTPUT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+services:
+- docker
+language: generic
+compiler:
+  - gcc
+notifications:
+  email:
+    on_failure: always
+    recipients:
+      - 130s@2000.jukuin.keio.ac.jp
+env:
+  matrix:
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu VERBOSE_OUTPUT=true
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu DEBUG_BASH=true
+    - ROS_DISTRO="kinetic" PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic" PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh

--- a/hebiros_description/CMakeLists.txt
+++ b/hebiros_description/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hebiros_description)
 
+find_package(catkin REQUIRED)
+
 catkin_package(
 )
 


### PR DESCRIPTION
You may or may not have been using CI (Continuous Integration) somewhere internally, but AFAICT on your public repo there's no trait for that, so goes this PR. CI is IMHO a way to go to avoid many problems including buildfarm hassles like https://github.com/HebiRobotics/HEBI-ROS/issues/11 ;)!

[ROS offers a few different ways](http://wiki.ros.org/CIs) to simplify setting up CI. In this PR, I'm suggesting [industrial_ci](http://wiki.ros.org/industrial_ci) (admittedly I'm one of the authors&maintainers). It's a set of scripts for CI on ROS. The simple config file in this PR enables CI to run on Travis CI for this repo, including [ROS pre-release test](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest) that is recommended for packages released on ROS buildfarm and is indeed suggested in the aforementioned ticket https://github.com/HebiRobotics/HEBI-ROS/issues/11#issuecomment-348054660.
Contrary to its name, it works for any ROS packages as well, not limited to "industrial" pkgs.

If this looks good, **can any admin enable Travis for this repo** at https://travis-ci.org/profile/HEBI-ROS?

----

It's totally up to the maintainers to use which CI tool, how to configure the detail, how to utilize the CI result etc. Just fyi that we as in [industrial_ci](http://wiki.ros.org/industrial_ci) maintainers have been very active in responding to questions and enhancement requests over a few years.
