### PR TITLE
Add ROS time stamps to published JointState messages

### DIFF
--- a/hebiros/include/hebiros/hebiros_subscribers_gazebo.cpp
+++ b/hebiros/include/hebiros/hebiros_subscribers_gazebo.cpp
@@ -48,6 +48,7 @@ void HebirosSubscribersGazebo::feedback(const boost::shared_ptr<FeedbackMsg cons
 
   FeedbackMsg feedback_msg = *data;
   sensor_msgs::JointState joint_state_msg;
+  joint_state_msg.header.stamp = ros::Time::now();
   joint_state_msg.name = feedback_msg.name;
   joint_state_msg.position = feedback_msg.position;
   joint_state_msg.velocity = feedback_msg.velocity;

--- a/hebiros/include/hebiros/hebiros_subscribers_physical.cpp
+++ b/hebiros/include/hebiros/hebiros_subscribers_physical.cpp
@@ -358,6 +358,7 @@ void HebirosSubscribersPhysical::feedback(std::string group_name, const GroupFee
     double velocity = group_fbk[i].actuator().velocity().get();
     double effort = group_fbk[i].actuator().effort().get();
 
+    joint_state_msg.header.stamp = ros::Time::now();
     joint_state_msg.name.push_back(family+"/"+name);
     joint_state_msg.position.push_back(position);
     joint_state_msg.velocity.push_back(velocity);


### PR DESCRIPTION
Added to support common ROS (visualization) tools that parse the `JointState.Header.time` field.

e.g. 
`rosrun rqt_plot rqt_plot /hebiros/GROUP_NAME/feedback/joint_state/effort[1]`