### PR TITLE
effort feedback - "80% solution"

### DIFF
--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_controller.cpp
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_controller.cpp
@@ -366,9 +366,9 @@ double HebirosGazeboController::ComputeForce(std::shared_ptr<HebirosGazeboGroup>
   hebiros_joint->temperature.update(power_in, iteration_time.toSec());
   hebiros_joint->temperature_safety.update(hebiros_joint->temperature.getMotorWindingTemperature());
 
-  //alpha = hebiros_joint->low_pass_alpha;
-  //force = (force * alpha) + hebiros_joint->prev_force * (1 - alpha);
-  //hebiros_joint->prev_force = force;
+  alpha = hebiros_joint->low_pass_alpha;
+  force = (force * alpha) + hebiros_joint->prev_force * (1 - alpha);
+  hebiros_joint->prev_force = force;
 
   return force;
 }

--- a/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
+++ b/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
@@ -24,6 +24,9 @@ void HebirosGazeboPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   this->update_connection = event::Events::ConnectWorldUpdateBegin (
     boost::bind(&HebirosGazeboPlugin::OnUpdate, this, _1));
 
+  this->prev_effort = 0.0;
+  this->low_pass_alpha = 0.1;
+
   ROS_INFO("Loaded hebiros gazebo plugin");
 }
 
@@ -73,6 +76,9 @@ void HebirosGazeboPlugin::UpdateGroup(std::shared_ptr<HebirosGazeboGroup> hebiro
       //effort = std::max(-20.0, std::min(20.0, effort));
       //effort += joint->GetForce(0);                             // torque from motor
       double effort = joint->GetForce(0);
+      double alpha = this->low_pass_alpha;
+      effort = (effort * alpha) + this->prev_effort * (1 - alpha);
+      this->prev_effort = effort;
 
       hebiros_group->feedback.position[i] = position;
       hebiros_group->feedback.velocity[i] = velocity;

--- a/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
+++ b/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
@@ -68,9 +68,7 @@ void HebirosGazeboPlugin::UpdateGroup(std::shared_ptr<HebirosGazeboGroup> hebiro
       joint->SetProvideFeedback(true);
       double position = joint->GetAngle(0).Radian();
       double velocity = joint->GetVelocity(0);
-      physics::JointWrench wrench = joint->GetForceTorque(0);
-      auto trans = joint->GetChild()->GetInitialRelativePose().rot;
-      double effort = (-1 * (trans * wrench.body1Torque)).z;
+      double effort = joint->GetForce(0);
 
       hebiros_group->feedback.position[i] = position;
       hebiros_group->feedback.velocity[i] = velocity;

--- a/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
+++ b/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
@@ -68,6 +68,10 @@ void HebirosGazeboPlugin::UpdateGroup(std::shared_ptr<HebirosGazeboGroup> hebiro
       joint->SetProvideFeedback(true);
       double position = joint->GetAngle(0).Radian();
       double velocity = joint->GetVelocity(0);
+      //physics::JointWrench wrench = joint->GetForceTorque(0u);  // Net torque (motor + environment). Non-zero values represent transient effects.
+      //double effort = -1*wrench.body2Torque.z;                  // reactive torque from motor
+      //effort = std::max(-20.0, std::min(20.0, effort));
+      //effort += joint->GetForce(0);                             // torque from motor
       double effort = joint->GetForce(0);
 
       hebiros_group->feedback.position[i] = position;


### PR DESCRIPTION
A few things I learned:

1. GetForceTorque() returns the **net force-torque** experienced by the Joint (e.g. for a X5-9 holding an arm at horizontal at steady-state, GetForceTorque() will return ~0.0 since the motor effort is being counteracted by the gravitational force). This is - as far as I can tell - not what we want for force-feedback control.

2. GetForce() simply returns the last **torque** applied to the Joint via SetForce. Using GetForce() is the 80% (cop-out) solution in my book - based off my tests. Now when playing with force-control using the real actuators, I noted that they are responsive to external forces. E.g. if a pendulum arm is partially lifted since the motor is set to apply a -1.4 N/m ("upwards") torque and I push down on the arm, it will temporarily reduce its torque output to compensate for the transient change in torque measured by the motor. Obviously GetForce() doesn't give us any of this, but GetForceTorque() might. See video below. Perhaps we could use the GetForce + (-GetForceTorque()) readings.

--
Videos:
GetForceTorque (dotted line) vs GetForce (solid line): 
https://drive.google.com/file/d/15vdITw2A4socnTJ0Ghwu5QT8UpQxQMBn/view?usp=sharing

force-torque-plugin readings while moving a joint:
https://drive.google.com/file/d/1HFzK05pN0u0opxflZ4954Bq0c4Co-UQ9/view?usp=sharing

---
Reference:
https://bitbucket.org/osrf/gazebo/issues/1975/changed-the-calculation-of-force-torque-on
https://bitbucket.org/osrf/gazebo/src/default/gazebo/sensors/ForceTorqueSensor.cc
https://bitbucket.org/osrf/gazebo/pull-requests/2110/changed-the-calculation-of-force-torque-on/diff
https://bitbucket.org/osrf/gazebo/src/default/gazebo/physics/ode/ODEJoint.cc