### PR TITLE
R links234/fix inconsistencies

### DIFF
--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_controller.cpp
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_controller.cpp
@@ -1,6 +1,4 @@
-
 #include <hebiros_gazebo_controller.h>
-
 
 namespace controller {
 
@@ -12,33 +10,33 @@ enum class control_strategies {
   CONTROL_STRATEGY_4 = 4
 };
 
-control_strategies DEFAULT_CONTROL_STRATEGY = control_strategies::CONTROL_STRATEGY_3;
+static constexpr control_strategies DEFAULT_CONTROL_STRATEGY = control_strategies::CONTROL_STRATEGY_3;
 
-    double MAX_PWM = 1.0;
-    double MIN_PWM = -1.0;
+static constexpr double MAX_PWM = 1.0;
+static constexpr double MIN_PWM = -1.0;
 
-    double LOW_PASS_ALPHA = 0.1;
+static constexpr double LOW_PASS_ALPHA = 0.1;
 
-    double DEFAULT_POSITION_KP = 0.5;
-    double DEFAULT_POSITION_KI = 0.0;
-    double DEFAULT_POSITION_KD = 0.0;
-    double DEFAULT_VELOCITY_KP = 0.05;
-    double DEFAULT_VELOCITY_KI = 0.0;
-    double DEFAULT_VELOCITY_KD = 0.0;
-    double DEFAULT_EFFORT_KP = 0.25;
-    double DEFAULT_EFFORT_KI = 0.0;
-    double DEFAULT_EFFORT_KD = 0.001;
+static constexpr double DEFAULT_POSITION_KP = 0.5;
+static constexpr double DEFAULT_POSITION_KI = 0.0;
+static constexpr double DEFAULT_POSITION_KD = 0.0;
+static constexpr double DEFAULT_VELOCITY_KP = 0.05;
+static constexpr double DEFAULT_VELOCITY_KI = 0.0;
+static constexpr double DEFAULT_VELOCITY_KD = 0.0;
+static constexpr double DEFAULT_EFFORT_KP = 0.25;
+static constexpr double DEFAULT_EFFORT_KI = 0.0;
+static constexpr double DEFAULT_EFFORT_KD = 0.001;
 
-    double GEAR_RATIO_X5_1 = 272.22;
-    double GEAR_RATIO_X8_3 = 272.22;
-    double GEAR_RATIO_X5_4 = 762.22;
-    double GEAR_RATIO_X8_9 = 762.22;
-    double GEAR_RATIO_X5_9 = 1742.22;
-    double GEAR_RATIO_X8_16 = 1462.222;
+static constexpr double GEAR_RATIO_X5_1 = 272.22;
+static constexpr double GEAR_RATIO_X8_3 = 272.22;
+static constexpr double GEAR_RATIO_X5_4 = 762.22;
+static constexpr double GEAR_RATIO_X8_9 = 762.22;
+static constexpr double GEAR_RATIO_X5_9 = 1742.22;
+static constexpr double GEAR_RATIO_X8_16 = 1462.222;
 
-    double DEFAULT_GEAR_RATIO = 272.22;
+static constexpr double DEFAULT_GEAR_RATIO = 272.22;
 
-std::map<std::string, double> gear_ratios = {
+static std::map<std::string, double> gear_ratios = {
   {"X5_1", GEAR_RATIO_X5_1},
   {"X5_4", GEAR_RATIO_X5_4},
   {"X5_9", GEAR_RATIO_X5_9},
@@ -49,10 +47,6 @@ std::map<std::string, double> gear_ratios = {
 
 using namespace controller;
 
-
-HebirosGazeboController::HebirosGazeboController() {}
-
-HebirosGazeboController::~HebirosGazeboController() {}
 
 //Set defaults settings for a joint once
 void HebirosGazeboController::SetSettings(std::shared_ptr<HebirosGazeboGroup> hebiros_group,
@@ -440,8 +434,7 @@ double HebirosGazeboController::ComputeForce(std::shared_ptr<HebirosGazeboGroup>
   float motor_velocity = velocity * gear_ratio;
   float speed_constant = 1530.0f;
   float term_resist = 9.99f;
-  if (hebiros_joint->isX8())
-  {
+  if (hebiros_joint->isX8()) {
     speed_constant = 1360.0f;
     term_resist = 3.19f;
   }

--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_controller.h
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_controller.h
@@ -1,6 +1,4 @@
-
-#ifndef _HEBIROS_GAZEBO_CONTROLLER_HH_
-#define _HEBIROS_GAZEBO_CONTROLLER_HH_
+#pragma once
 
 #include "ros/ros.h"
 #include "hebiros_gazebo_group.h"
@@ -8,34 +6,37 @@
 
 using namespace hebiros;
 
-
 class HebirosGazeboController {
 
-  public:
+public:
 
-    HebirosGazeboController();
-    ~HebirosGazeboController();
-    static double ComputeForce(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
-      double position, double velocity, double effort, const ros::Duration& iteration_time);
-    static double ComputePositionPID(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
-      double target_position, double position, const ros::Duration& iteration_time);
-    static double ComputeVelocityPID(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
-      double target_velocity, double velocity, const ros::Duration& iteration_time);
-    static double ComputeEffortPID(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
-      double target_effort, double effort, const ros::Duration& iteration_time);
-    static void SetSettings(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint);
-    static void ChangeSettings(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint);
-    static void SetDefaultGains(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
-      std::shared_ptr<HebirosGazeboJoint> hebiros_joint);
-    static double Clip(double x, double low, double high);
+  HebirosGazeboController() = default;
+  
+  static double ComputeForce(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
+    double position, double velocity, double effort, const ros::Duration& iteration_time);
+  
+  static double ComputePositionPID(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
+    double target_position, double position, const ros::Duration& iteration_time);
+  
+  static double ComputeVelocityPID(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
+    double target_velocity, double velocity, const ros::Duration& iteration_time);
+  
+  static double ComputeEffortPID(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint,
+    double target_effort, double effort, const ros::Duration& iteration_time);
+  
+  static void SetSettings(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint);
+  
+  static void ChangeSettings(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint);
+  
+  static void SetDefaultGains(std::shared_ptr<HebirosGazeboGroup> hebiros_group, 
+    std::shared_ptr<HebirosGazeboJoint> hebiros_joint);
+  
+  static double Clip(double x, double low, double high);
 
 };
-
-
-#endif

--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_group.cpp
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_group.cpp
@@ -1,4 +1,3 @@
-
 #include <hebiros_gazebo_group.h>
 #include "hebiros_gazebo_controller.h"
 
@@ -29,8 +28,6 @@ HebirosGazeboGroup::HebirosGazeboGroup(std::string name,
     "hebiros_gazebo_plugin/set_feedback_frequency/"+name, boost::bind(
     &HebirosGazeboGroup::SrvSetFeedbackFrequency, this, _1, _2));
 }
-
-HebirosGazeboGroup::~HebirosGazeboGroup() {}
 
 void HebirosGazeboGroup::SubCommand(const boost::shared_ptr<CommandMsg const> data) {
 

--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_group.h
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_group.h
@@ -1,6 +1,4 @@
-
-#ifndef _HEBIROS_GAZEBO_GROUP_HH_
-#define _HEBIROS_GAZEBO_GROUP_HH_
+#pragma once
 
 #include "ros/ros.h"
 #include "std_srvs/Empty.h"
@@ -13,43 +11,38 @@
 
 using namespace hebiros;
 
-
 class HebirosGazeboGroup : public std::enable_shared_from_this<HebirosGazeboGroup> {
 
-  public:
+public:
 
-    std::string name;
-    std::map<std::string, std::shared_ptr<HebirosGazeboJoint>> joints;
-    FeedbackMsg feedback;
-    CommandMsg command_target;
-    SettingsMsg settings;
-    bool check_acknowledgement = false;
-    bool acknowledgement = false;
-    bool command_received = false;
-    bool group_added = false;
-    int command_lifetime = 100;
-    int feedback_frequency = 100;
+  // TODO: Make these private.
+  std::string name;
+  std::map<std::string, std::shared_ptr<HebirosGazeboJoint>> joints;
+  FeedbackMsg feedback;
+  CommandMsg command_target;
+  SettingsMsg settings;
+  bool check_acknowledgement = false;
+  bool acknowledgement = false;
+  bool command_received = false;
+  bool group_added = false;
+  int command_lifetime = 100;
+  int feedback_frequency = 100;
 
-    ros::Time start_time;
-    ros::Time prev_time;
-    ros::Time prev_feedback_time;
+  ros::Time start_time;
+  ros::Time prev_time;
+  ros::Time prev_feedback_time;
 
-    ros::Subscriber command_sub;
-    ros::Publisher feedback_pub;
-    ros::ServiceServer acknowledge_srv;
-    ros::ServiceServer command_lifetime_srv;
-    ros::ServiceServer feedback_frequency_srv;
+  ros::Subscriber command_sub;
+  ros::Publisher feedback_pub;
+  ros::ServiceServer acknowledge_srv;
+  ros::ServiceServer command_lifetime_srv;
+  ros::ServiceServer feedback_frequency_srv;
 
-    HebirosGazeboGroup(std::string name, std::shared_ptr<ros::NodeHandle> n);
-    ~HebirosGazeboGroup();
-    void SubCommand(const boost::shared_ptr<CommandMsg const> data);
-    bool SrvAcknowledge(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
-    bool SrvSetCommandLifetime(SetCommandLifetimeSrv::Request &req,
-      SetCommandLifetimeSrv::Response &res);
-    bool SrvSetFeedbackFrequency(SetFeedbackFrequencySrv::Request &req,
-      SetFeedbackFrequencySrv::Response &res);
+  HebirosGazeboGroup(std::string name, std::shared_ptr<ros::NodeHandle> n);
+
+  void SubCommand(const boost::shared_ptr<CommandMsg const> data);
+  bool SrvAcknowledge(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
+  bool SrvSetCommandLifetime(SetCommandLifetimeSrv::Request &req, SetCommandLifetimeSrv::Response &res);
+  bool SrvSetFeedbackFrequency(SetFeedbackFrequencySrv::Request &req, SetFeedbackFrequencySrv::Response &res);
 
 };
-
-
-#endif

--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_joint.cpp
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_joint.cpp
@@ -1,6 +1,4 @@
-
 #include <hebiros_gazebo_joint.h>
-
 
 HebirosGazeboJoint::HebirosGazeboJoint(const std::string& name_,
   const std::string& model_name_,
@@ -15,11 +13,8 @@ HebirosGazeboJoint::HebirosGazeboJoint(const std::string& name_,
     100, boost::bind(&HebirosGazeboJoint::SubIMU, this, _1));
 }
 
-HebirosGazeboJoint::~HebirosGazeboJoint() {}
-
 //Subscriber which receives IMU feedback from gazebo
 void HebirosGazeboJoint::SubIMU(const boost::shared_ptr<sensor_msgs::Imu const> data) {
-
   this->accelerometer = data->linear_acceleration;
   this->gyro = data->angular_velocity;
 }

--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_joint.h
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_joint.h
@@ -1,6 +1,4 @@
-
-#ifndef _HEBIROS_GAZEBO_JOINT_HH_
-#define _HEBIROS_GAZEBO_JOINT_HH_
+#pragma once
 
 #include "ros/ros.h"
 #include "sensor_msgs/Imu.h"
@@ -10,37 +8,35 @@
 
 class HebirosGazeboJoint : public std::enable_shared_from_this<HebirosGazeboJoint> {
 
-  public:
+public:
 
-    std::string name;
-    std::string model_name;
-    geometry_msgs::Vector3 accelerometer;
-    geometry_msgs::Vector3 gyro;
+  // TODO: Make these private.
+  std::string name;
+  std::string model_name;
+  geometry_msgs::Vector3 accelerometer;
+  geometry_msgs::Vector3 gyro;
 
-    int feedback_index;
-    int command_index;
+  int feedback_index;
+  int command_index;
 
-    hebiros::sim::TemperatureModel temperature;
-    hebiros::sim::TemperatureSafetyController temperature_safety{155};
+  hebiros::sim::TemperatureModel temperature;
+  hebiros::sim::TemperatureSafetyController temperature_safety{155};
 
-    double prev_force {};
-    double low_pass_alpha {};
-    double gear_ratio {};
-    double position_prev_error {};
-    double position_elapsed_error {};
-    double velocity_prev_error {};
-    double velocity_elapsed_error {};
-    double effort_prev_error {};
-    double effort_elapsed_error {};
+  double prev_force {};
+  double low_pass_alpha {};
+  double gear_ratio {};
+  double position_prev_error {};
+  double position_elapsed_error {};
+  double velocity_prev_error {};
+  double velocity_elapsed_error {};
+  double effort_prev_error {};
+  double effort_elapsed_error {};
 
-    ros::Subscriber imu_subscriber;
+  ros::Subscriber imu_subscriber;
 
-    HebirosGazeboJoint(const std::string& name, const std::string& model_name, bool is_x8, std::shared_ptr<ros::NodeHandle> n);
-    ~HebirosGazeboJoint();
-    void SubIMU(const boost::shared_ptr<sensor_msgs::Imu const> data);
+  HebirosGazeboJoint(const std::string& name, const std::string& model_name, bool is_x8, std::shared_ptr<ros::NodeHandle> n);
 
-    bool isX8() const;
+  void SubIMU(const boost::shared_ptr<sensor_msgs::Imu const> data);
+  bool isX8() const;
+
 };
-
-
-#endif

--- a/hebiros_gazebo_plugin/include/hebiros_gazebo_plugin.h
+++ b/hebiros_gazebo_plugin/include/hebiros_gazebo_plugin.h
@@ -1,6 +1,4 @@
-
-#ifndef _HEBIROS_GAZEBO_PLUGIN_HH_
-#define _HEBIROS_GAZEBO_PLUGIN_HH_
+#pragma once
 
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
@@ -27,32 +25,28 @@ using namespace gazebo;
 
 class HebirosGazeboPlugin: public ModelPlugin {
 
-  public:
-    HebirosGazeboPlugin();
-    ~HebirosGazeboPlugin();
-    void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
-    void OnUpdate(const common::UpdateInfo & _info);
+public:
+  HebirosGazeboPlugin() = default;
 
-  private:
+  void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  void OnUpdate(const common::UpdateInfo & _info);
 
-    physics::ModelPtr model;
-    event::ConnectionPtr update_connection;
-    std::map<std::string, std::shared_ptr<HebirosGazeboGroup>> hebiros_groups;
-    std::map<std::string, std::shared_ptr<HebirosGazeboJoint>> hebiros_joints;
+private:
 
-    std::string robot_namespace;
-    std::shared_ptr<ros::NodeHandle> n;
-    ros::Subscriber command_sub;
-    ros::ServiceServer add_group_srv;
-    ros::ServiceServer acknowledge_srv;
+  physics::ModelPtr model;
+  event::ConnectionPtr update_connection;
+  std::map<std::string, std::shared_ptr<HebirosGazeboGroup>> hebiros_groups;
+  std::map<std::string, std::shared_ptr<HebirosGazeboJoint>> hebiros_joints;
 
-    void AddJointToGroup(std::shared_ptr<HebirosGazeboGroup> hebiros_group, std::string joint_name);
-    void UpdateGroup(std::shared_ptr<HebirosGazeboGroup> hebiros_group, const ros::Duration& iteration_time);
+  std::string robot_namespace;
+  std::shared_ptr<ros::NodeHandle> n;
+  ros::Subscriber command_sub;
+  ros::ServiceServer add_group_srv;
+  ros::ServiceServer acknowledge_srv;
 
-    bool SrvAddGroup(AddGroupFromNamesSrv::Request &req,
-      AddGroupFromNamesSrv::Response &res);
+  void AddJointToGroup(std::shared_ptr<HebirosGazeboGroup> hebiros_group, std::string joint_name);
+  void UpdateGroup(std::shared_ptr<HebirosGazeboGroup> hebiros_group, const ros::Duration& iteration_time);
+
+  bool SrvAddGroup(AddGroupFromNamesSrv::Request &req, AddGroupFromNamesSrv::Response &res);
 
 };
-
-
-#endif

--- a/hebiros_gazebo_plugin/include/hebiros_temperature_model.cpp
+++ b/hebiros_gazebo_plugin/include/hebiros_temperature_model.cpp
@@ -1,51 +1,53 @@
 #include "hebiros_temperature_model.h"
 
 namespace hebiros {
-  namespace sim {
-    TemperatureModel TemperatureModel::createX5() {
-      double r_be = 8.0; // (found experimentally from steady-state experiments)
-      return TemperatureModel(
-        2.57 * 1.8,     // r_wh (datasheet)
-        1.0,            // r_hb (Open air from data sheet divided by empirical factor)
-        r_be,              
-        0.943 / 2.57,   // c_w (winding, datasheet; tc_winding / rth_winding)
-        390.0 / 23.5,   // c_h (housing, datasheet) (TC / R)
-        10000.0 / r_be  // c_b actuator body; from experimentally measured time constant
-      );
-    }
+namespace sim {
 
-    TemperatureModel TemperatureModel::createX8() {
-      double r_be = 4.0; // (found experimentally from steady-state experiments)
-      return TemperatureModel(
-        1.41 * 1.6,     // r_wh (datasheet)
-        1.0,            // r_hb (Open air from data sheet divided by empirical factor)
-        r_be,              
-        0.9 / 1.41,     // c_w (winding, datasheet; tc_winding / rth_winding)
-        427.0 / 17.7,   // c_h (housing, datasheet) (TC / R)
-        10000.0 / r_be  // c_b actuator body; from experimentally measured time constant
-      );
-    }
+TemperatureModel TemperatureModel::createX5() {
+  double r_be = 8.0; // (found experimentally from steady-state experiments)
+  return TemperatureModel(
+    2.57 * 1.8,     // r_wh (datasheet)
+    1.0,            // r_hb (Open air from data sheet divided by empirical factor)
+    r_be,              
+    0.943 / 2.57,   // c_w (winding, datasheet; tc_winding / rth_winding)
+    390.0 / 23.5,   // c_h (housing, datasheet) (TC / R)
+    10000.0 / r_be  // c_b actuator body; from experimentally measured time constant
+  );
+}
 
-    // Perform an update of all of the stages of the model,
-    // based on the estimated power going into the system
-    void TemperatureModel::update(double power_in, double dt) {
-      // The heat flux between each stage; we calculate
-      // these all _before_ updating the temperatures
-      double q_wh = (t_w_ - t_h_) / r_wh_;
-      double q_hb = (t_h_ - t_b_) / r_hb_;
-      double q_be = (t_b_ - t_e_) / r_be_;
-      
-      // Update the temperature of each phase
-      t_w_ += (power_in - q_wh) * dt / c_w_;
-      t_h_ += (q_wh - q_hb) * dt / c_h_;
-      t_b_ += (q_hb - q_be) * dt / c_b_;
-    }
+TemperatureModel TemperatureModel::createX8() {
+  double r_be = 4.0; // (found experimentally from steady-state experiments)
+  return TemperatureModel(
+    1.41 * 1.6,     // r_wh (datasheet)
+    1.0,            // r_hb (Open air from data sheet divided by empirical factor)
+    r_be,              
+    0.9 / 1.41,     // c_w (winding, datasheet; tc_winding / rth_winding)
+    427.0 / 17.7,   // c_h (housing, datasheet) (TC / R)
+    10000.0 / r_be  // c_b actuator body; from experimentally measured time constant
+  );
+}
 
-    TemperatureModel::TemperatureModel(
-      double r_wh, double r_hb, double r_be,
-      double c_w, double c_h, double c_b)
-      : r_wh_(r_wh), r_hb_(r_hb), r_be_(r_be), 
-        c_w_(c_w), c_h_(c_h), c_b_(c_b) {
-    }
-  }
+// Perform an update of all of the stages of the model,
+// based on the estimated power going into the system
+void TemperatureModel::update(double power_in, double dt) {
+  // The heat flux between each stage; we calculate
+  // these all _before_ updating the temperatures
+  double q_wh = (t_w_ - t_h_) / r_wh_;
+  double q_hb = (t_h_ - t_b_) / r_hb_;
+  double q_be = (t_b_ - t_e_) / r_be_;
+  
+  // Update the temperature of each phase
+  t_w_ += (power_in - q_wh) * dt / c_w_;
+  t_h_ += (q_wh - q_hb) * dt / c_h_;
+  t_b_ += (q_hb - q_be) * dt / c_b_;
+}
+
+TemperatureModel::TemperatureModel(
+  double r_wh, double r_hb, double r_be,
+  double c_w, double c_h, double c_b)
+  : r_wh_(r_wh), r_hb_(r_hb), r_be_(r_be), 
+    c_w_(c_w), c_h_(c_h), c_b_(c_b) {
+}
+
+}
 }

--- a/hebiros_gazebo_plugin/include/hebiros_temperature_model.h
+++ b/hebiros_gazebo_plugin/include/hebiros_temperature_model.h
@@ -1,43 +1,45 @@
 #pragma once
 
 namespace hebiros {
-  namespace sim {
-    // A simple multi-stage actuator temperature model.
-    class TemperatureModel {
-    public:
-      static TemperatureModel createX5();
-      static TemperatureModel createX8();
+namespace sim {
 
-      void update(double power_in, double dt);
+// A simple multi-stage actuator temperature model.
+class TemperatureModel {
+public:
+  static TemperatureModel createX5();
+  static TemperatureModel createX8();
 
-      // Winding temperature
-      double getMotorWindingTemperature() { return t_w_; }
-      double getMotorHousingTemperature() { return t_h_; }
-      double getActuatorBodyTemperature() { return t_b_; }
+  void update(double power_in, double dt);
 
-    private:
-      TemperatureModel(
-        double r_wh, double r_hb, double r_be,
-        double c_w, double c_h, double c_b);
+  // Winding temperature
+  double getMotorWindingTemperature() { return t_w_; }
+  double getMotorHousingTemperature() { return t_h_; }
+  double getActuatorBodyTemperature() { return t_b_; }
 
-      // Thermal resistances: winding-housing, housing-body, body-environment
-      const double r_wh_;
-      const double r_hb_;
-      const double r_be_;
+private:
+  TemperatureModel(
+    double r_wh, double r_hb, double r_be,
+    double c_w, double c_h, double c_b);
 
-      // Thermal capacitances: winding, housing, body
-      const double c_w_;
-      const double c_h_;
-      const double c_b_;
+  // Thermal resistances: winding-housing, housing-body, body-environment
+  const double r_wh_;
+  const double r_hb_;
+  const double r_be_;
 
-      // State variables - these are the bodies for which we
-      // model temperature
-      double t_w_{34.0}; // Motor winding
-      double t_h_{34.0}; // Motor housing
-      double t_b_{32.0}; // Actuator body
+  // Thermal capacitances: winding, housing, body
+  const double c_w_;
+  const double c_h_;
+  const double c_b_;
 
-      // Environment temperature (in *C) ; assume room temperature + fudge factor
-      static constexpr double t_e_{32.0};
-    };
-  }
+  // State variables - these are the bodies for which we
+  // model temperature
+  double t_w_{34.0}; // Motor winding
+  double t_h_{34.0}; // Motor housing
+  double t_b_{32.0}; // Actuator body
+
+  // Environment temperature (in *C) ; assume room temperature + fudge factor
+  static constexpr double t_e_{32.0};
+};
+
+}
 }

--- a/hebiros_gazebo_plugin/include/temperature_safety_controller.cpp
+++ b/hebiros_gazebo_plugin/include/temperature_safety_controller.cpp
@@ -1,31 +1,32 @@
 #include "temperature_safety_controller.h"
 
 namespace hebiros {
-  namespace sim {
+namespace sim {
 
-    TemperatureSafetyController::TemperatureSafetyController(double max_temp) 
-      : max_temp_(max_temp) {
-    }
+TemperatureSafetyController::TemperatureSafetyController(double max_temp) 
+  : max_temp_(max_temp) {
+}
 
-    void TemperatureSafetyController::update(double measured_temp) {
-      if (measured_temp >= max_temp_) {
-        max_pwm_ = 0;
-        return;
-      }
-      float d_val = max_temp_ - measured_temp;
-      float d_pwm = lambda_ / d_val;
-      if (d_pwm > 1.0)    
-        max_pwm_ = 0;
-      else
-        max_pwm_ = 1.0 - d_pwm;
-    }
-
-    double TemperatureSafetyController::limit(double raw_value) {
-      if (raw_value > max_pwm_)
-        return max_pwm_;
-      else if (raw_value < -max_pwm_)
-        return -max_pwm_;
-      return raw_value;
-    }
+void TemperatureSafetyController::update(double measured_temp) {
+  if (measured_temp >= max_temp_) {
+    max_pwm_ = 0;
+    return;
   }
+  float d_val = max_temp_ - measured_temp;
+  float d_pwm = lambda_ / d_val;
+  if (d_pwm > 1.0)    
+    max_pwm_ = 0;
+  else
+    max_pwm_ = 1.0 - d_pwm;
+}
+
+double TemperatureSafetyController::limit(double raw_value) {
+  if (raw_value > max_pwm_)
+    return max_pwm_;
+  else if (raw_value < -max_pwm_)
+    return -max_pwm_;
+  return raw_value;
+}
+
+}
 }

--- a/hebiros_gazebo_plugin/include/temperature_safety_controller.h
+++ b/hebiros_gazebo_plugin/include/temperature_safety_controller.h
@@ -1,19 +1,22 @@
 #pragma once
 
 namespace hebiros {
-  namespace sim {
-    // A simple multi-stage actuator temperature model.
-    class TemperatureSafetyController {
-    public:
-      TemperatureSafetyController(double max_temp);
+namespace sim {
 
-      void update(double measured_temp);
-      double limit(double raw_value);
+// A simple multi-stage actuator temperature model.
+class TemperatureSafetyController {
+public:
+  TemperatureSafetyController(double max_temp);
 
-    private:
-      double max_temp_;
-      double lambda_{1};
-      double max_pwm_{1};
-    };
-  }
+  void update(double measured_temp);
+  double limit(double raw_value);
+
+private:
+  double max_temp_;
+  double lambda_{1};
+  double max_pwm_{1};
+
+};
+
+}
 }

--- a/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
+++ b/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
@@ -1,14 +1,7 @@
-
 #include <hebiros_gazebo_plugin.h>
-
-
-HebirosGazeboPlugin::HebirosGazeboPlugin() {}
-
-HebirosGazeboPlugin::~HebirosGazeboPlugin() {}
 
 //Load the model and sdf from Gazebo
 void HebirosGazeboPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
-
   this->model = _model;
 
   int argc = 0;
@@ -38,7 +31,6 @@ void HebirosGazeboPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
 
 //Update the joints at every simulation iteration
 void HebirosGazeboPlugin::OnUpdate(const common::UpdateInfo & _info) {
-
   ros::Time current_time = ros::Time::now();
 
   for (auto group_pair : hebiros_groups) {
@@ -55,12 +47,10 @@ void HebirosGazeboPlugin::OnUpdate(const common::UpdateInfo & _info) {
 
 //Publish feedback and compute PID control to command a joint
 void HebirosGazeboPlugin::UpdateGroup(std::shared_ptr<HebirosGazeboGroup> hebiros_group, const ros::Duration& iteration_time) {
-
   for (auto joint_pair : hebiros_group->joints) {
 
     std::string joint_name = joint_pair.first;
     std::shared_ptr<HebirosGazeboJoint> hebiros_joint = hebiros_group->joints[joint_name];
-
 
     physics::JointPtr joint = this->model->GetJoint(joint_name+"/"+hebiros_joint->model_name);
 


### PR DESCRIPTION
These are just small changes to make the Gazebo code a bit more consistent. No functional changes were made. Mainly, this contains replacing header guards with `#pragma once`, removes namespace indentations, removes trivial constructors/destructors, and adds private linkage to some variables **which are only used in one translation unit**.