### PR TITLE
Update simulation to compile on kinetic + melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ env:
     - ROS_DISTRO="kinetic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu VERBOSE_OUTPUT=false
     - ROS_DISTRO="kinetic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu DEBUG_BASH=true
     - ROS_DISTRO="kinetic" PRERELEASE=true
+    - ROS_DISTRO="melodic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu VERBOSE_OUTPUT=false
+    - ROS_DISTRO="melodic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu DEBUG_BASH=true
+    - ROS_DISTRO="melodic" PRERELEASE=true
 matrix:
   allow_failures:
     - env: ROS_DISTRO="kinetic" PRERELEASE=true
+    - env: ROS_DISTRO="melodic" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,9 @@ env:
     - ROS_DISTRO="kinetic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu VERBOSE_OUTPUT=false
     - ROS_DISTRO="kinetic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu DEBUG_BASH=true
     - ROS_DISTRO="kinetic" PRERELEASE=true
-    - ROS_DISTRO="melodic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu VERBOSE_OUTPUT=false
-    - ROS_DISTRO="melodic" NOT_TEST_BUILD=true ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu DEBUG_BASH=true
-    - ROS_DISTRO="melodic" PRERELEASE=true
 matrix:
   allow_failures:
     - env: ROS_DISTRO="kinetic" PRERELEASE=true
-    - env: ROS_DISTRO="melodic" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/hebiros_gazebo_plugin/CMakeLists.txt
+++ b/hebiros_gazebo_plugin/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hebiros_gazebo_plugin)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-#add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
+++ b/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
@@ -3,7 +3,7 @@
 // Checks the content of a string before the first "." at compile time.
 // Necessary because Gazebo only defines string version numbers.
 // Note: This requires -std=c++14 or higher to compile
-constexpr int GetGazeboVersion ( char const* string_ver )
+constexpr int GetGazeboVersion (char const* string_ver)
 {
   int res = 0;
   int i = 0;
@@ -18,7 +18,12 @@ constexpr int GetGazeboVersion ( char const* string_ver )
 // This is a templated struct that allows for wrapping some of the Gazebo
 // code for which compilation differse between versions; we use partial
 // template specialization to compile the appropriate version.
-template<int GazeboVersion, class JointType> struct GazeboHelper;
+template<int GazeboVersion, class JointType> struct GazeboHelper {
+  static_assert(GazeboVersion == 7 || GazeboVersion == 9, "Unknown version of gazebo");
+  // Default implementations so that the above assertion is the only compilation error
+  static double position(JointType joint) { return 0; }
+  static double effort(JointType joint) { return 0; }
+};
 
 template<class JointType> struct GazeboHelper<7, JointType> {
   static double position(JointType joint) {

--- a/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
+++ b/hebiros_gazebo_plugin/plugin/hebiros_gazebo_plugin.cpp
@@ -3,8 +3,7 @@
 // Checks the content of a string before the first "." at compile time.
 // Necessary because Gazebo only defines string version numbers.
 // Note: This requires -std=c++14 or higher to compile
-constexpr int GetGazeboVersion (char const* string_ver)
-{
+constexpr int GetGazeboVersion (char const* string_ver) {
   int res = 0;
   int i = 0;
   while (string_ver[i] != '\0' && string_ver[i] >= '0' && string_ver[i] <= '9') {
@@ -18,14 +17,14 @@ constexpr int GetGazeboVersion (char const* string_ver)
 // This is a templated struct that allows for wrapping some of the Gazebo
 // code for which compilation differse between versions; we use partial
 // template specialization to compile the appropriate version.
-template<int GazeboVersion, class JointType> struct GazeboHelper {
+template<int GazeboVersion, typename JointType> struct GazeboHelper {
   static_assert(GazeboVersion == 7 || GazeboVersion == 9, "Unknown version of gazebo");
   // Default implementations so that the above assertion is the only compilation error
   static double position(JointType joint) { return 0; }
   static double effort(JointType joint) { return 0; }
 };
 
-template<class JointType> struct GazeboHelper<7, JointType> {
+template<typename JointType> struct GazeboHelper<7, JointType> {
   static double position(JointType joint) {
     return joint->GetAngle(0).Radian(); 
   }
@@ -37,7 +36,7 @@ template<class JointType> struct GazeboHelper<7, JointType> {
   }
 };
 
-template<class JointType> struct GazeboHelper<9, JointType> {
+template<typename JointType> struct GazeboHelper<9, JointType> {
   static double position(JointType joint) {
     return joint->Position(0);
   }


### PR DESCRIPTION
Gazebo plugin depended on kinetic-specific (gazebo 7) function calls;
this has been updated to conditionally compile for gazebo 7 or 9.